### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -6,7 +6,10 @@ on:
       - '**/*.md'
       - '**/*.txt'
   workflow_dispatch:
-  
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Potential fix for [https://github.com/SANATASMIA/javasec/security/code-scanning/16](https://github.com/SANATASMIA/javasec/security/code-scanning/16)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for all jobs. Since the specific permissions required by the reusable workflows are not provided, we will start with a minimal configuration of `contents: read`. If any of the reusable workflows require additional permissions, they can be explicitly defined within those workflows or overridden in the main workflow for specific jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
