### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -1,4 +1,6 @@
 name: 20 SCA
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/SANATASMIA/javasec/security/code-scanning/14](https://github.com/SANATASMIA/javasec/security/code-scanning/14)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the `contents: read` permission is sufficient, as the workflow primarily involves checking out the repository, setting up Java, and installing tools. No write permissions are necessary.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
